### PR TITLE
Issue5

### DIFF
--- a/data_manager_conf.xml
+++ b/data_manager_conf.xml
@@ -1,0 +1,24 @@
+<!-- <?xml version="1.0"?>
+<data_managers>
+</data_managers> -->
+
+<?xml version="1.0"?>
+<data_managers> <!-- The root element -->
+    <data_manager tool_file="data_manager/fetch_genome_all_fasta.xml" id="fetch_genome_all_fasta"> <data_managers> <!-- Defines a single Data Manager Tool that can update one or more Data Tables -->
+        <data_table name="all_fasta"> <!-- Defines a Data Table to be modified. -->
+            <output> <!-- Handle the output of the Data Manager Tool -->
+                <column name="value" /> <!-- columns that are going to be specified by the Data Manager Tool -->
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="out_file" >  <!-- The value of this column will be modified based upon data in "out_file". example value "phiX.fa" -->
+                    <move type="file"> <!-- Moving a file from the extra files path of "out_file" -->
+                        <source>${path}</source> <!-- File name within the extra files path -->
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">${dbkey}/seq/${path}</target> <!-- Target Location to store the file, directories are created as needed -->
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${dbkey}/seq/${path}</value_translation> <!-- Store this value in the final Data Table -->
+                </column>
+            </output>
+        </data_table>
+        <!-- additional data_tables can be configured from a single Data Manager -->
+    </data_manager>
+</<data_managers>>

--- a/galaxy.ini
+++ b/galaxy.ini
@@ -242,7 +242,7 @@ tool_config_file = config/tool_conf.xml,config/shed_tool_conf.xml
 # Directory where data used by tools is located, see the samples in that
 # directory and the wiki for help:
 #   https://wiki.galaxyproject.org/Admin/DataIntegration
-#tool_data_path = tool-data
+tool_data_path = .
 
 # Directory where Tool Data Table related files will be placed
 # when installed from a ToolShed. Defaults to tool_data_path.
@@ -886,7 +886,7 @@ use_interactive = True
 # of the server, and will have access to create users, groups, roles,
 # libraries, and more.  For more information, see:
 #   https://wiki.galaxyproject.org/Admin/Interface
-#admin_users = None
+admin_users = yanyul@andrew.cmu.edu
 
 # Force everyone to log in (disable anonymous access).
 #require_login = False
@@ -1025,14 +1025,14 @@ use_interactive = True
 
 # Data manager configuration options
 # Allow non-admin users to view available Data Manager options.
-#enable_data_manager_user_view = False
+enable_data_manager_user_view = False
 # File where Data Managers are configured (.sample used if default does not
 # exist).
-#data_manager_config_file = config/data_manager_conf.xml
+data_manager_config_file = config/data_manager_conf.xml
 # File where Tool Shed based Data Managers are configured.
-#shed_data_manager_config_file = config/shed_data_manager_conf.xml
+shed_data_manager_config_file = config/shed_data_manager_conf.xml
 # Directory to store Data Manager based tool-data; defaults to tool_data_path.
-#galaxy_data_manager_data_path = tool-data
+galaxy_data_manager_data_path = tool-data
 
 # -- Job Execution
 

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,9 @@ cp galaxy.ini galaxy/config
 cp tool_conf.xml galaxy/config
 cp datatypes_conf.xml galaxy/config
 cp requirements.txt galaxy/requirements.txt
+cp data_manager_conf.xml galaxy/config/data_manager_conf.xml
+cp -r data galaxy/
+cp tool_data_table_conf.xml galaxy/config/tool_data_table_conf.xml
 rsync -ruv datatypes/ galaxy/lib/galaxy/datatypes/
 rsync -ruv tools/ galaxy/tools/
 rsync -ruv tool-data/ galaxy/tool-data # for future usage

--- a/tool-data/load_built_in.loc
+++ b/tool-data/load_built_in.loc
@@ -1,0 +1,6 @@
+#This file lists the locations of metadata for cellorganizer
+#under the "cellorganizer" directory 
+
+
+#<name>	<value>	<file_path>
+Hela_2D_Cell	hela_2d_cell	/Users/yanyu_liang/cellorganizer-galaxy/galaxy/data/Hela_2D_Cell.tar

--- a/tool_conf.xml
+++ b/tool_conf.xml
@@ -6,4 +6,7 @@
   <section name="TIFF to collection of JPEG" id="cell">
     <tool file="cellorganizer/demo2D00.xml" />
   </section>
+  <section id="loaddata" name="Load Metadata of CellOrganizer">
+    <tool file="load_metadata/load_metadata.xml" />
+  </section>
 </toolbox>

--- a/tools/load_metadata/load_metadata.sh
+++ b/tools/load_metadata/load_metadata.sh
@@ -1,0 +1,4 @@
+mkdir tmp 
+cd tmp
+tar -xf $1
+cd ../

--- a/tools/load_metadata/load_metadata.xml
+++ b/tools/load_metadata/load_metadata.xml
@@ -1,0 +1,27 @@
+<tool id="load_metadata" name="Load Built-in Data" version="0.0.1">
+  <description>From here you can select and load metadata of CellOrganizer as a dataset collection into your history</description>
+  <command interpreter="bash">load_metadata.sh ${datasets.fields.path} </command>
+  <inputs>
+    <param name="datasets" type="select" label="Select a Dataset">
+      <options from_data_table="load_built_in_indexes">
+        <filter type="sort_by" column="2" />
+          <validator type="no_options" message="No indexes are available" />
+        </options>
+   </param>       
+  </inputs>
+
+  <outputs>
+        <collection type="list" label="$datasets" name="output1">
+            <discover_datasets pattern="(?P&lt;name&gt;.*)" directory="tmp" />
+        </collection>
+  </outputs>
+  
+<help>
+
+
+**Description**
+
+Help you load metadata
+
+</help>
+</tool>

--- a/tools/load_metadata/test.py
+++ b/tools/load_metadata/test.py
@@ -1,0 +1,21 @@
+import argparse
+import sys
+import os
+
+def parser():
+    parser = argparse.ArgumentParser(description="Generates some sample documents in a dataset")
+    parser.add_argument('--output_path', required=True, action="store", type=str, help="Path to output file")
+    return parser.parse_args()
+
+
+if __name__=='__main__':
+
+        args = parser()
+
+        outdir = args.output_path
+
+        if not os.path.exists(args.output_path):
+            os.makedirs(args.output_path)
+        for name in ['asdsds', 'dafafqf', 'wvwev']:
+            with open(os.path.join(outdir, name + ".dsds"), 'w') as out:
+                out.write("%s, 1.3\n" % name)


### PR DESCRIPTION
Added a tool called "Load Metadata of CellOrganizer" where user can select built-in datasets as a collection and add them to user's history by clicking "execute" button.

Now the built-in data locates at /data, and each dataset collection is a tarball (generated by `tar -cvf mytar.tar *`). 

To let the tool know where are those files, we need to fill in the newly added files at /tool-data/load_built_in.loc. Now the path is **absolute path** (I cannot fix this inconvenience, so when you want to run it on your computer, you need to modify "/tool-data/load_built_in.loc" to change the directory to yours) 